### PR TITLE
Fixed uncompress for GO 1.22

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -15,7 +15,7 @@ func Uncompress(content Content, ignore int) Content {
 	for _, sheet := range sheets {
 		rows := sheet.TableRow
 
-		for _, row := range rows {
+		for ridx, row := range rows {
 			cells := row.TableCell
 
 			// Create a new slice for the row's cells
@@ -42,7 +42,7 @@ func Uncompress(content Content, ignore int) Content {
 				}
 			}
 
-			row.TableCell = newCells
+			rows[ridx].TableCell = newCells
 		}
 
 		sheet.TableRow = rows


### PR DESCRIPTION
Uncompress does not work properly when compiled with GO 1.22, this is caused by the new [loop var](https://go.dev/blog/loopvar-preview) feature 