### PR TITLE
Added ReadFrom which takes io.Reader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/AlexJarrah/go-ods
+module github.com/ash-claireit/go-ods
 
 go 1.21.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ash-claireit/go-ods
+module github.com/AlexJarrah/go-ods
 
 go 1.21.5


### PR DESCRIPTION
The hardcoded filepath wasn't fitting for our usecase so I moved most of the logic to a generic ReadFrom function that takes an io.Reader instead of a filepath and redirected Read to use this.

Tested by opening an pre-filled ods file and reading data from it.